### PR TITLE
code.py

### DIFF
--- a/code.py
+++ b/code.py
@@ -1,16 +1,19 @@
 import time
-import wifi
+import os
+import board
+import busio
+import displayio
+import digitalio
+from digitalio import DigitalInOut, Pull
 import socketpool
 import ssl
 import adafruit_requests
-import board
-import digitalio
-from digitalio import DigitalInOut, Pull
-from adafruit_debouncer import Debouncer
-import busio
-import displayio
 import adafruit_displayio_sh1106
-import os
+from adafruit_debouncer import Debouncer
+import wifi
+import adafruit_ble
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
 
 # WiFi credentials
 ssid = os.getenv("CIRCUITPY_WIFI_SSID")
@@ -32,6 +35,11 @@ down_button_pin = DigitalInOut(board.IO18)  # Use the correct pin for your down 
 down_button_pin.pull = Pull.UP
 down_button = Debouncer(down_button_pin)
 
+# Set up BLE
+ble = adafruit_ble.BLERadio()
+uart_service = UARTService()
+advertisement = ProvideServicesAdvertisement(uart_service)
+
 # Function to send reboot request
 def send_reboot_request():
     pool = socketpool.SocketPool(wifi.radio)
@@ -49,16 +57,34 @@ def send_reboot_request():
 
 # Main loop
 print("RESTART ROUTER:")
-print("PRESS DOWN BUTTON")
+print("PRESS DOWN BUTTON OR SEND 'reboot' VIA BLE")
 while True:
-    down_button.update()
+    # BLE connection handling
+    if not ble.connected:
+        ble.start_advertising(advertisement)
+    else:
+        ble.stop_advertising()
 
+        # Check for incoming BLE data
+        if uart_service.in_waiting:
+            command = uart_service.read(uart_service.in_waiting)
+            command = command.decode("utf-8").strip()
+
+            # Trigger reboot request when receiving a specific command (e.g., "reboot")
+            if command == "reboot":
+                print("Received reboot command via BLE")
+                response = send_reboot_request()
+                print(f"Response: {response.status_code}\n{response.text}")
+                print("DONE!")
+                time.sleep(10)
+
+    # Button check
+    down_button.update()
     if down_button.fell:
         print("Sending reboot request...")
         response = send_reboot_request()
         print(f"Response: {response.status_code}\n{response.text}")
-
         print("DONE!")
-        time.sleep(10)  # Wait for 10 seconds
+        time.sleep(10)
 
     time.sleep(0.1)  # Small delay to reduce CPU usage


### PR DESCRIPTION
To integrate the Bluetooth functionality with the provided script, we will add the necessary BLE components. The integrated script will maintain its ability to connect to Wi-Fi, send a reboot request, and handle a physical button press. In addition, it will listen for Bluetooth commands to trigger the same reboot action.This script now has the capability to handle both a physical button press and a BLE command to trigger the reboot request. When the BLE UART service receives the string "reboot", it executes the same action as the button press. The BLE device will advertise when not connected, allowing for easy discovery and connection by BLE central devices (like smartphones with nRF Connect or LightBlue).
To interact with this script using nRF Connect (for Android or iOS) or LightBlue (for iOS):

nRF Connect
Open nRF Connect on your smartphone.
Scan for Bluetooth devices and connect to your CircuitPython device (it should be advertising as a BLE UART service).
Once connected, go to the "UART" service and find the UART characteristic.
Write the string "reboot" to this characteristic and send it. This should trigger the reboot request.

LightBlue
Open LightBlue on your iPhone.
Scan for Bluetooth devices and connect to your CircuitPython device.
Explore the services and look for the UART service.
Write the string "reboot" to the appropriate characteristic to trigger the reboot request.